### PR TITLE
Switched to double quotes

### DIFF
--- a/src/cli-option.coffee
+++ b/src/cli-option.coffee
@@ -37,8 +37,7 @@ class CliOption
     prefix + @option
 
   _formatOptionWithArgs: ->
-    args = _.map @args, ((s) -> Util.surroundSingleQuote s)
-    argsString = Util.quoteAll(args).join ' '
+    argsString = Util.quoteAll(@args, true).join ' '
     if @option.length == 1
       "-#{@option} #{argsString}"
     else

--- a/src/util.coffee
+++ b/src/util.coffee
@@ -19,16 +19,13 @@ util =
     regexp = new RegExp("([#{chars.join('')}])", 'g')
     s.replace regexp, "#{escapeChar}$1"
 
-  surroundSingleQuote: (s) ->
-    s.replace /'/g, "'\"'\"'"
-
   quote: (value, escape=false) ->
-    value = value.replace(/'/g, "\\'") if escape
-    "'#{value}'"
+    value = value.replace(/"/g, "\\\"") if escape
+    "\"#{value}\""
 
-  quoteAll: (values) ->
+  quoteAll: (values, escape=false) ->
     _.map values, (value) =>
-      @quote value
+      @quote value, escape
 
   setOptions: (options, callback) ->
     if _.isFunction(options) && !callback?

--- a/test/cli-command-test.coffee
+++ b/test/cli-command-test.coffee
@@ -40,9 +40,9 @@ describe 'CliCommand', ->
 
     it 'should format command with options', ->
       command = new CliCommand('pacman', { S: 'abc', verbose: '' })
-      expect(command.toString()).to.be "pacman -S 'abc' --verbose"
+      expect(command.toString()).to.be "pacman -S \"abc\" --verbose"
       command = new CliCommand(['git', 'commit'], { m: 'my message', a: '' })
-      expect(command.toString()).to.be "git commit -m 'my message' -a"
+      expect(command.toString()).to.be "git commit -m \"my message\" -a"
 
     it 'should format command with arguments and options', ->
       command = new CliCommand(['git', 'diff'], ['HEAD~5', 'HEAD', '--', 'README.md'], { s: '' })

--- a/test/cli-option-test.coffee
+++ b/test/cli-option-test.coffee
@@ -34,12 +34,12 @@ describe 'CliOption', ->
 
     it 'should format short options with args', ->
       option = new CliOption('m', 'lorem ipsum')
-      expected = "-m 'lorem ipsum'"
+      expected = "-m \"lorem ipsum\""
       expect(option.toString()).to.be expected
 
     it 'should format long options with args', ->
       option = new CliOption('message', 'lorem ipsum')
-      expected = "--message='lorem ipsum'"
+      expected = "--message=\"lorem ipsum\""
       expect(option.toString()).to.be expected
 
     it 'should ignore "true"', ->

--- a/test/util-test.coffee
+++ b/test/util-test.coffee
@@ -32,15 +32,15 @@ describe 'util', ->
 
   describe 'quote', ->
     it 'should quote raw argument', ->
-      expect(util.quote('foo')).to.be "'foo'"
+      expect(util.quote('foo')).to.be "\"foo\""
 
     it 'should escape string quotes', ->
-      expect(util.quote("foo'", true)).to.be "'foo\\''"
-      expect(util.quote("'foo'", true)).to.be "'\\'foo\\''"
+      expect(util.quote("foo\"", true)).to.be '"foo\\""'
+      expect(util.quote("\"foo\"", true)).to.be '"\\"foo\\""'
 
   describe 'quoteAll', ->
     it 'should quote all elements', ->
-      expect(util.quoteAll(["foo", "bar"])).to.eql ["'foo'", "'bar'"]
+      expect(util.quoteAll(["foo", "bar"])).to.eql ["\"foo\"", "\"bar\""]
 
   describe 'escape', ->
     it 'should escape quotes by default', ->


### PR DESCRIPTION
This makes it work in Windows cmd.exe, where single quotes don't escape.