### PR TITLE
Allow log to accept options and callback

### DIFF
--- a/src/stats.coffee
+++ b/src/stats.coffee
@@ -35,7 +35,7 @@ exports.status = (options, callback) ->
     _.each(statusInfo, (f) => f.fullPath = "#{@workingDir()}/#{f.path}")
   execute command, @_getOptions(), cb
 
-exports.log = (options={}) ->
+exports.log = (options={}, callback) ->
   [options, callback] = util.setOptions options, callback
   format = '{"author": "%an", "email": "%ae", "date": "%cd", "subject": "%s", "body": "%b", "hash": "%H"},'
   cliOpts = _.extend({ pretty: "format:#{format}" }, options)

--- a/test/repository-test.coffee
+++ b/test/repository-test.coffee
@@ -150,6 +150,13 @@ describe 'Repository', ->
         expect(logs[0].date).to.be.a Date
         done()
 
+    it.only 'should accept options and return logs', (done) ->
+      testRepository.log { n: 1 }, (err, logs) ->
+        expect(err).to.be null
+        expect(logs).to.be.an Array
+        expect(logs).to.have.length 1
+        done()
+
   describe '#commit', ->
     it 'should work when files are added', (done) ->
       fs.appendFileSync("#{testRepository.workingDir()}/README.md", 'foobar')


### PR DESCRIPTION
As far as I can tell, the existing code lets you pass either an {{options}} object or a {{callback}} function in its place, but not both. Please mock me if I'm wrong.